### PR TITLE
fix: add schema.json for schematics referenced in collection.json

### DIFF
--- a/src/collection.json
+++ b/src/collection.json
@@ -5,27 +5,32 @@
     "store": {
       "factory": "./factories/store/store.factory#store",
       "description": "Create a NGXS full store",
-      "aliases": ["ngxs-store"]
+      "aliases": ["ngxs-store"],
+      "schema": "./factories/store/schema.json"
     },
     "state": {
       "factory": "./factories/state/state.factory#state",
       "description": "Create a NGXS state",
-      "aliases": ["ngxs-state"]
+      "aliases": ["ngxs-state"],
+      "schema": "./factories/state/schema.json"
     },
     "actions": {
       "factory": "./factories/actions/actions.factory#actions",
       "description": "Create a NGXS actions",
-      "aliases": ["ngxs-actions"]
+      "aliases": ["ngxs-actions"],
+      "schema": "./factories/actions/schema.json"
     },
     "starter-kit": {
       "factory": "./factories/starter-kit/starter-kit.factory#starterKit",
       "description": "Create a NGXS starter kit with simple or best practise type",
-      "aliases": ["ngxs-sk"]
+      "aliases": ["ngxs-sk"],
+      "schema": "./factories/starter-kit/schema.json"
     },
     "ng-add": {
       "factory": "./factories/ng-add/ng-add.factory#ngAdd",
       "description": "Add Ngxs Store and plugins in package.json",
-      "aliases": ["ngxs-init"]
+      "aliases": ["ngxs-init"],
+      "schema": "./factories/ng-add/schema.json"
     }
   }
 }

--- a/src/factories/actions/schema.json
+++ b/src/factories/actions/schema.json
@@ -1,0 +1,27 @@
+{
+    "$schema": "http://json-schema.org/schema",
+    "id": "SchematicsNgxsActions",
+    "title": "Ngxs Actions Options Schema",
+    "type": "object",
+    "properties": {
+        "name": {
+            "description": "The name of the actions.",
+            "type": "string",
+            "$default": {
+                "$source": "argv",
+                "index": 0
+            }
+        },
+        "path": {
+            "type": "string",
+            "format": "path",
+            "description": "The path to create the actions."
+        },
+        "sourceRoot": {
+            "type": "string",
+            "format": "path",
+            "description": "The source root path"
+        }
+    },
+    "required": []
+}

--- a/src/factories/ng-add/schema.json
+++ b/src/factories/ng-add/schema.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "http://json-schema.org/schema",
+    "id": "SchematicsNgxsNgAdd",
+    "title": "Ngxs NgAdd Options Schema",
+    "type": "object",
+    "properties": {
+        "skipInstall": {
+            "type": "boolean",
+            "description": "The flag to skip packages installing.",
+            "default": false
+        }
+    },
+    "required": []
+}

--- a/src/factories/starter-kit/schema.json
+++ b/src/factories/starter-kit/schema.json
@@ -1,0 +1,24 @@
+{
+    "$schema": "http://json-schema.org/schema",
+    "id": "SchematicsNgxsStarterKit",
+    "title": "Ngxs Starter Kit Options Schema",
+    "type": "object",
+    "properties": {
+        "path": {
+            "type": "string",
+            "format": "path",
+            "description": "The path to create the starter kit."
+        },
+        "sourceRoot": {
+            "type": "string",
+            "format": "path",
+            "description": "The source root path"
+        },
+        "spec": {
+            "type": "boolean",
+            "description": "Specifies if a spec file is generated.",
+            "default": true
+        }
+    },
+    "required": []
+}

--- a/src/factories/starter-kit/schema.json
+++ b/src/factories/starter-kit/schema.json
@@ -17,7 +17,7 @@
         "spec": {
             "type": "boolean",
             "description": "Specifies if a spec file is generated.",
-            "default": true
+            "default": false
         }
     },
     "required": []

--- a/src/factories/state/schema.json
+++ b/src/factories/state/schema.json
@@ -25,7 +25,7 @@
         "spec": {
             "type": "boolean",
             "description": "Specifies if a spec file is generated.",
-            "default": true
+            "default": false
         }
     },
     "required": []

--- a/src/factories/state/schema.json
+++ b/src/factories/state/schema.json
@@ -1,0 +1,32 @@
+{
+    "$schema": "http://json-schema.org/schema",
+    "id": "SchematicsNgxsState",
+    "title": "Ngxs State Options Schema",
+    "type": "object",
+    "properties": {
+        "name": {
+            "description": "The name of the state.",
+            "type": "string",
+            "$default": {
+                "$source": "argv",
+                "index": 0
+            }
+        },
+        "path": {
+            "type": "string",
+            "format": "path",
+            "description": "The path to create the state."
+        },
+        "sourceRoot": {
+            "type": "string",
+            "format": "path",
+            "description": "The source root path"
+        },
+        "spec": {
+            "type": "boolean",
+            "description": "Specifies if a spec file is generated.",
+            "default": true
+        }
+    },
+    "required": []
+}

--- a/src/factories/store/schema.json
+++ b/src/factories/store/schema.json
@@ -25,7 +25,7 @@
         "spec": {
             "type": "boolean",
             "description": "Specifies if a spec file is generated.",
-            "default": true
+            "default": false
         }
     },
     "required": []

--- a/src/factories/store/schema.json
+++ b/src/factories/store/schema.json
@@ -1,0 +1,32 @@
+{
+    "$schema": "http://json-schema.org/schema",
+    "id": "SchematicsNgxsStore",
+    "title": "Ngxs Store Options Schema",
+    "type": "object",
+    "properties": {
+        "name": {
+            "description": "The name of the store.",
+            "type": "string",
+            "$default": {
+                "$source": "argv",
+                "index": 0
+            }
+        },
+        "path": {
+            "type": "string",
+            "format": "path",
+            "description": "The path to create the store."
+        },
+        "sourceRoot": {
+            "type": "string",
+            "format": "path",
+            "description": "The source root path"
+        },
+        "spec": {
+            "type": "boolean",
+            "description": "Specifies if a spec file is generated.",
+            "default": true
+        }
+    },
+    "required": []
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[x] Other... Please describe: Additional integration materials
```

## What is the current behavior?
Currently schemas are only implemented in TypeScript, IE schema.d.ts - which can only be used at compile/design time as TypeScript types do not emit code. Using the 'schema.json' method makes this information available at run-time as well. It is used by the Angular CLI as well as [Angular Console](https://angularconsole.com/) to provide interactive hints to users.

Issue Number: #14 

## What is the new behavior?
Adds JSON schemas for each schematic so that the Angular CLI can provide hints to users as well as enable integration with [Angular Console](https://angularconsole.com/)

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
https://github.com/nrwl/angular-console/issues/204