### PR TITLE
refactor: remove duplicate symbols

### DIFF
--- a/src/factories/ng-add/ng-add.factory.ts
+++ b/src/factories/ng-add/ng-add.factory.ts
@@ -1,8 +1,13 @@
 import { chain, noop, Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
-import { LIB_CONFIG, LibConfigInterface } from '../../utils/common/lib.config';
 import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
+import {
+  addPackageJsonDependency,
+  NodeDependency
+} from '@schematics/angular/utility/dependencies';
+
+import { LIB_CONFIG } from '../../utils/common/lib.config';
+
 import { NgxsPackageSchema } from './ng-add.schema';
-import { addPackageJsonDependency } from '@schematics/angular/utility/dependencies';
 
 export function ngAdd(options: NgxsPackageSchema): Rule {
   return chain([
@@ -16,7 +21,7 @@ export function ngAdd(options: NgxsPackageSchema): Rule {
 function addNgxsPackageToPackageJson() {
   return (host: Tree, context: SchematicContext) => {
     context.logger.info('Adding npm dependencies');
-    LIB_CONFIG.forEach(({ type, version, name, overwrite }: LibConfigInterface) => {
+    LIB_CONFIG.forEach(({ type, version, name, overwrite }: NodeDependency) => {
       addPackageJsonDependency(host, { type, version, name, overwrite });
       context.logger.log('info', `✅️ Added "${name}" into ${type}`);
     });

--- a/src/utils/common/lib.config.ts
+++ b/src/utils/common/lib.config.ts
@@ -1,3 +1,5 @@
+import { NodeDependency, NodeDependencyType } from '@schematics/angular/utility/dependencies';
+
 const packageJson = require('../../../package.json');
 
 export enum LIBRARIES {
@@ -7,21 +9,7 @@ export enum LIBRARIES {
   SCHEMATICS = '@ngxs/schematics'
 }
 
-export enum NodeDependencyType {
-  Default = 'dependencies',
-  Dev = 'devDependencies',
-  Peer = 'peerDependencies',
-  Optional = 'optionalDependencies'
-}
-
-export interface LibConfigInterface {
-  type: NodeDependencyType;
-  name: string;
-  version: string;
-  overwrite?: boolean;
-}
-
-export const LIB_CONFIG: LibConfigInterface[] = [
+export const LIB_CONFIG: NodeDependency[] = [
   {
     type: NodeDependencyType.Default,
     name: LIBRARIES.DEVTOOLS,

--- a/src/utils/get-library.ts
+++ b/src/utils/get-library.ts
@@ -1,7 +1,9 @@
-import { LIB_CONFIG, LibConfigInterface, NodeDependencyType } from './common/lib.config';
+import { NodeDependencyType, NodeDependency } from '@schematics/angular/utility/dependencies';
+
+import { LIB_CONFIG } from './common/lib.config';
 
 export function depsToAdd(type: NodeDependencyType): string[] {
-  return LIB_CONFIG.filter((pkg: LibConfigInterface) => pkg.type === type)
+  return LIB_CONFIG.filter((pkg: NodeDependency) => pkg.type === type)
     .reduce((acc, pkg) => [...acc, pkg.name], [])
     .sort();
 }

--- a/test/factories/ng-add/ng-add.factory.test.ts
+++ b/test/factories/ng-add/ng-add.factory.test.ts
@@ -1,8 +1,10 @@
 import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';
+import { Tree } from '@angular-devkit/schematics';
+import { NodeDependencyType } from '@schematics/angular/utility/dependencies';
+
 import * as path from 'path';
 import * as fs from 'fs';
-import { Tree } from '@angular-devkit/schematics';
-import { NodeDependencyType } from '../../../src/utils/common/lib.config';
+
 import { depsToAdd } from '../../../src/utils/get-library';
 
 describe('ng-add package in package.json', () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
`NodeDependencyType` and `LibConfigInterface` (`NodeDependency`) already exists in `@schematics/angular/utility/dependencies`.

## What is the new behavior?
Import the symbols from `@schematics/angular/utility/dependencies`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```